### PR TITLE
Fix: track crafting-tree check-offs per appearance, not per item name

### DIFF
--- a/apps/web/components/base-requirements-list.tsx
+++ b/apps/web/components/base-requirements-list.tsx
@@ -5,34 +5,44 @@ import { useEffect } from "react";
 import { MinecraftColoredText } from "@/components/minecraft-colored-text";
 import { trackBaseRequirementsView } from "@/lib/analytics";
 import { useRecipeData } from "@/lib/recipe-data-context";
-import { getBaseRequirements } from "@/lib/recipe-utils";
+import {
+  getBaseRequirements,
+  getFrontierRequirements,
+} from "@/lib/recipe-utils";
 import { getDisplayName } from "@/lib/utils";
 import { ItemImage } from "./item-image";
 
 interface BaseRequirementsListProps {
   internalname: string;
   multiplier: number;
+  todoMode?: boolean;
   checkedItems?: Set<string>;
 }
 
 export function BaseRequirementsList({
   internalname,
   multiplier,
+  todoMode,
   checkedItems,
 }: BaseRequirementsListProps) {
   const { recipes, itemsData } = useRecipeData();
-  const baseRequirements = getBaseRequirements(
-    internalname,
-    recipes,
-    multiplier,
-    {},
-    new Set(),
-    itemsData,
-  );
+  // In todo mode, show the most granular items still needed (frontier), rolling
+  // up to the next un-crafted parent as leaves get checked off.
+  const baseRequirements =
+    todoMode && checkedItems
+      ? getFrontierRequirements(internalname, recipes, multiplier, checkedItems)
+      : getBaseRequirements(
+          internalname,
+          recipes,
+          multiplier,
+          {},
+          new Set(),
+          itemsData,
+        );
 
-  const sortedRequirements = Object.entries(baseRequirements)
-    .filter(([name]) => !checkedItems?.has(name))
-    .sort(([, a], [, b]) => b - a);
+  const sortedRequirements = Object.entries(baseRequirements).sort(
+    ([, a], [, b]) => b - a,
+  );
 
   useEffect(() => {
     if (sortedRequirements.length > 0) {

--- a/apps/web/components/combined-materials-list.tsx
+++ b/apps/web/components/combined-materials-list.tsx
@@ -10,14 +10,10 @@ export function CombinedMaterialsList(props: {
   baseRequirements: Record<string, number>;
   materialDepth: number;
   onMaterialDepthChange: (depth: number) => void;
-  checkedItems?: Set<string>;
+  todoMode?: boolean;
 }) {
-  const {
-    baseRequirements,
-    materialDepth,
-    onMaterialDepthChange,
-    checkedItems,
-  } = props;
+  const { baseRequirements, materialDepth, onMaterialDepthChange, todoMode } =
+    props;
   const { recipes, itemsData } = useRecipeData();
 
   const isBase = !Number.isFinite(materialDepth);
@@ -29,37 +25,40 @@ export function CombinedMaterialsList(props: {
           <Clipboard className="w-4 h-4 text-primary" />
           <h3 className="font-semibold text-sm">Combined Materials</h3>
         </div>
-        <div className="flex rounded-md bg-muted/60 p-0.5 border border-border/40">
-          <button
-            type="button"
-            onClick={() => onMaterialDepthChange(1)}
-            className={`flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-all ${
-              !isBase
-                ? "bg-card text-foreground shadow-sm border border-border/40"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            <Layers className="w-3 h-3" />
-            Crafting
-          </button>
-          <button
-            type="button"
-            onClick={() => onMaterialDepthChange(Number.POSITIVE_INFINITY)}
-            className={`flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-all ${
-              isBase
-                ? "bg-card text-foreground shadow-sm border border-border/40"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            <Pickaxe className="w-3 h-3" />
-            Raw
-          </button>
-        </div>
+        {/* In todo mode the frontier defines granularity dynamically, so the
+            Crafting/Raw depth toggle is hidden. */}
+        {!todoMode && (
+          <div className="flex rounded-md bg-muted/60 p-0.5 border border-border/40">
+            <button
+              type="button"
+              onClick={() => onMaterialDepthChange(1)}
+              className={`flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-all ${
+                !isBase
+                  ? "bg-card text-foreground shadow-sm border border-border/40"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Layers className="w-3 h-3" />
+              Crafting
+            </button>
+            <button
+              type="button"
+              onClick={() => onMaterialDepthChange(Number.POSITIVE_INFINITY)}
+              className={`flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium transition-all ${
+                isBase
+                  ? "bg-card text-foreground shadow-sm border border-border/40"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Pickaxe className="w-3 h-3" />
+              Raw
+            </button>
+          </div>
+        )}
       </div>
       <div className="p-4">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-1.5">
           {Object.entries(baseRequirements)
-            .filter(([name]) => !checkedItems?.has(name))
             .sort(([, a], [, b]) => b - a)
             .map(([materialName, count]) => {
               const entry = recipes[materialName] || itemsData[materialName];

--- a/apps/web/components/crafting-tree-multi.tsx
+++ b/apps/web/components/crafting-tree-multi.tsx
@@ -23,7 +23,7 @@ export function CraftingTreeMulti(props: {
   todoMode: boolean;
   onToggleTodoMode: () => void;
   checkedItems: Set<string>;
-  onToggleChecked: (id: string) => void;
+  onToggleChecked: (path: string, internalname: string) => void;
 }) {
   const {
     selectedItemId,

--- a/apps/web/components/crafting-tree-single.tsx
+++ b/apps/web/components/crafting-tree-single.tsx
@@ -19,7 +19,7 @@ export function CraftingTreeSingle(props: {
   todoMode: boolean;
   onToggleTodoMode: () => void;
   checkedItems: Set<string>;
-  onToggleChecked: (id: string) => void;
+  onToggleChecked: (path: string, internalname: string) => void;
 }) {
   const {
     selectedItem,

--- a/apps/web/components/recipe-tree.tsx
+++ b/apps/web/components/recipe-tree.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
 import type React from "react";
 import { MinecraftColoredText } from "@/components/minecraft-colored-text";
 import { trackRecipeTreeItemClick } from "@/lib/analytics";
-import { BASE_MATERIALS } from "@/lib/constants";
+import { BASE_MATERIALS, PATH_DELIM } from "@/lib/constants";
 import {
   calculateOptimalForgeTime,
   formatForgeTime,
@@ -22,6 +22,9 @@ import { ItemImage } from "./item-image";
 
 interface RecipeTreeProps {
   internalname: string;
+  /** Unique node path (root->node internalname chain). Defaults to the
+   * internalname for the root node. */
+  path?: string;
   multiplier?: number;
   depth?: number;
   visited?: Set<string>;
@@ -32,11 +35,12 @@ interface RecipeTreeProps {
   ancestorLines?: boolean[];
   todoMode?: boolean;
   checkedItems?: Set<string>;
-  onToggleChecked?: (itemName: string) => void;
+  onToggleChecked?: (path: string, internalname: string) => void;
 }
 
 export function RecipeTree({
   internalname,
+  path,
   multiplier = 1,
   depth = 0,
   visited = new Set(),
@@ -51,6 +55,7 @@ export function RecipeTree({
 }: RecipeTreeProps): React.ReactElement | null {
   const { recipes, itemsData } = useRecipeData();
 
+  const nodePath = path ?? internalname;
   const expandedItems = externalExpandedItems ?? new Set([internalname]);
 
   if (visited.has(internalname)) {
@@ -104,7 +109,7 @@ export function RecipeTree({
         entry.info[0])
       : undefined;
 
-  const isChecked = todoMode && checkedItems?.has(internalname);
+  const isChecked = todoMode && checkedItems?.has(nodePath);
 
   return (
     <div>
@@ -146,7 +151,7 @@ export function RecipeTree({
           {todoMode && onToggleChecked && (
             <Checkbox
               checked={!!isChecked}
-              onCheckedChange={() => onToggleChecked(internalname)}
+              onCheckedChange={() => onToggleChecked(nodePath, internalname)}
               onClick={(e) => e.stopPropagation()}
               className="flex-shrink-0"
             />
@@ -223,6 +228,7 @@ export function RecipeTree({
             <RecipeTree
               key={name}
               internalname={name}
+              path={`${nodePath}${PATH_DELIM}${name}`}
               multiplier={count * actualMultiplier}
               depth={depth + 1}
               visited={nextVisited}

--- a/apps/web/components/skyblock-calculator-client.tsx
+++ b/apps/web/components/skyblock-calculator-client.tsx
@@ -17,7 +17,7 @@ import { useRecipeTreeExpansion } from "@/hooks/use-recipe-tree-expansion";
 import { useSharedRecipe } from "@/hooks/use-shared-recipe";
 import { useSharedRecipeLoader } from "@/hooks/use-shared-recipe-loader";
 import { useCalculatorStore } from "@/lib/calculator-store";
-import { BASE_MATERIALS } from "@/lib/constants";
+import { BASE_MATERIALS, PATH_DELIM } from "@/lib/constants";
 import { useRecipeData } from "@/lib/recipe-data-context";
 import {
   aggregateIngredients,
@@ -125,33 +125,42 @@ export function SkyblockCalculatorClient() {
     (mode === "multi" && itemList.length > 0);
 
   const handleToggleChecked = useCallback(
-    (itemName: string) => {
-      const getDescendants = (
+    (path: string, internalname: string) => {
+      // Collect the PATHS of every descendant within this node's own subtree,
+      // mirroring the tree's branch-local `visited` cycle guard so the cascade
+      // matches exactly the nodes rendered under this parent.
+      const collectDescendantPaths = (
         name: string,
-        visited: Set<string> = new Set(),
+        basePath: string,
+        visited: Set<string>,
       ): string[] => {
-        if (visited.has(name)) return [];
-        visited.add(name);
-
         const entry = recipes[name];
-        if (!entry) return [];
+        const recipe = entry ? getRecipe(entry) : undefined;
+        if (!recipe || BASE_MATERIALS.has(name)) return [];
 
-        const recipe = getRecipe(entry);
-        if (!recipe) return [];
-
-        const ingredients = getIngredientsFromRecipe(recipe);
-        if (ingredients.length === 0 || BASE_MATERIALS.has(name)) return [];
-
-        const counts = aggregateIngredients(ingredients);
+        const counts = aggregateIngredients(getIngredientsFromRecipe(recipe));
         const result: string[] = [];
         for (const child of Object.keys(counts)) {
-          result.push(child);
-          result.push(...getDescendants(child, visited));
+          if (visited.has(child)) continue;
+          const childPath = `${basePath}${PATH_DELIM}${child}`;
+          result.push(childPath);
+          result.push(
+            ...collectDescendantPaths(
+              child,
+              childPath,
+              new Set(visited).add(child),
+            ),
+          );
         }
         return result;
       };
 
-      toggleChecked(itemName, getDescendants(itemName));
+      // The path is the chain of ancestor names; use it to seed the cycle guard.
+      const ancestorNames = new Set(path.split(PATH_DELIM));
+      toggleChecked(
+        path,
+        collectDescendantPaths(internalname, path, ancestorNames),
+      );
     },
     [recipes, toggleChecked],
   );
@@ -312,7 +321,8 @@ export function SkyblockCalculatorClient() {
                     <BaseRequirementsList
                       internalname={selectedItem}
                       multiplier={multiplier}
-                      checkedItems={todoMode ? checkedItems : undefined}
+                      todoMode={todoMode}
+                      checkedItems={checkedItems}
                     />
                   </div>
                 </div>
@@ -321,7 +331,7 @@ export function SkyblockCalculatorClient() {
                   baseRequirements={baseRequirements}
                   materialDepth={materialDepth}
                   onMaterialDepthChange={setMaterialDepth}
-                  checkedItems={todoMode ? checkedItems : undefined}
+                  todoMode={todoMode}
                 />
               )}
             </div>

--- a/apps/web/hooks/use-calculator-results.ts
+++ b/apps/web/hooks/use-calculator-results.ts
@@ -7,7 +7,9 @@ import { useRecipeData } from "@/lib/recipe-data-context";
 import {
   getBaseRequirements,
   getCombinedBaseRequirements,
+  getCombinedFrontierRequirements,
   getCombinedRequirementsAtDepth,
+  getFrontierRequirements,
 } from "@/lib/recipe-utils";
 import type { ForgeSettings } from "@/lib/types";
 
@@ -28,9 +30,21 @@ export function useCalculatorResults(
 
   const baseRequirements = useMemo(() => {
     if (mode === "single" && selectedItem) {
+      // In todo mode, show the most granular items still needed (frontier).
+      if (checkedItems) {
+        return getFrontierRequirements(
+          selectedItem,
+          recipes,
+          multiplier,
+          checkedItems,
+        );
+      }
       return getBaseRequirements(selectedItem, recipes, multiplier);
     }
     if (mode === "multi") {
+      if (checkedItems) {
+        return getCombinedFrontierRequirements(itemList, recipes, checkedItems);
+      }
       if (Number.isFinite(materialDepth)) {
         return getCombinedRequirementsAtDepth(
           itemList,
@@ -50,6 +64,7 @@ export function useCalculatorResults(
     recipes,
     itemsData,
     materialDepth,
+    checkedItems,
   ]);
 
   const totalMaterials = Object.keys(baseRequirements).length;

--- a/apps/web/lib/calculator-store.ts
+++ b/apps/web/lib/calculator-store.ts
@@ -32,9 +32,11 @@ interface CalculatorState {
 
   // Todo mode
   todoMode: boolean;
+  // Set of checked-off node PATHS (root->node internalname chains), so each
+  // appearance of an item in the tree is tracked independently.
   checkedItems: Set<string>;
   toggleTodoMode: () => void;
-  toggleChecked: (itemName: string, descendants: string[]) => void;
+  toggleChecked: (path: string, descendantPaths: string[]) => void;
 
   // Hydration
   hydrated: boolean;
@@ -130,15 +132,15 @@ export const useCalculatorStore = create<CalculatorState>((set, get) => ({
     });
     if (clearing) saveJson(LOCAL_KEYS.checkedItems, []);
   },
-  toggleChecked: (itemName, descendants) => {
+  toggleChecked: (path, descendantPaths) => {
     const prev = get().checkedItems;
     const next = new Set(prev);
-    if (next.has(itemName)) {
-      next.delete(itemName);
-      for (const d of descendants) next.delete(d);
+    if (next.has(path)) {
+      next.delete(path);
+      for (const d of descendantPaths) next.delete(d);
     } else {
-      next.add(itemName);
-      for (const d of descendants) next.add(d);
+      next.add(path);
+      for (const d of descendantPaths) next.add(d);
     }
     set({ checkedItems: next });
     saveJson(LOCAL_KEYS.checkedItems, Array.from(next));

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,3 +1,8 @@
+// Delimiter for building unique tree-path identifiers from internalnames.
+// Internalnames contain "_", ":", ";" and "-" but never control chars, so the
+// unit separator (U+001F) is a safe, collision-free join character.
+export const PATH_DELIM = "";
+
 // Items to always treat as base (never recurse into their recipes)
 export const BASE_MATERIALS = new Set([
   "IRON_INGOT",

--- a/apps/web/lib/forge-time-utils.ts
+++ b/apps/web/lib/forge-time-utils.ts
@@ -1,3 +1,4 @@
+import { PATH_DELIM } from "@/lib/constants";
 import {
   aggregateIngredients,
   getIngredientsFromRecipe,
@@ -56,10 +57,12 @@ export function getTotalForgeTime(
     useMultipleSlots: true,
     quickForgeLevel: 0,
   },
-  excludeItems?: Set<string>,
+  checkedPaths?: Set<string>,
+  path: string = internalname,
 ): number {
   if (visited.has(internalname)) return 0;
-  if (excludeItems?.has(internalname)) return 0;
+  // A checked-off node excludes its whole subtree's forge time.
+  if (checkedPaths?.has(path)) return 0;
   const newVisited = new Set(visited);
   newVisited.add(internalname);
 
@@ -84,7 +87,8 @@ export function getTotalForgeTime(
       count * multiplier,
       newVisited,
       options,
-      excludeItems,
+      checkedPaths,
+      `${path}${PATH_DELIM}${name}`,
     );
   }
   return total;
@@ -145,7 +149,7 @@ export function getCombinedForgeTime(
     useMultipleSlots: true,
     quickForgeLevel: 0,
   },
-  excludeItems?: Set<string>,
+  checkedPaths?: Set<string>,
 ): number {
   let totalTime = 0;
 
@@ -156,7 +160,8 @@ export function getCombinedForgeTime(
       quantity,
       new Set(),
       options,
-      excludeItems,
+      checkedPaths,
+      itemId,
     );
     totalTime += time;
   }

--- a/apps/web/lib/recipe-utils.ts
+++ b/apps/web/lib/recipe-utils.ts
@@ -1,4 +1,4 @@
-import { BASE_MATERIALS } from "./constants";
+import { BASE_MATERIALS, PATH_DELIM } from "./constants";
 import type {
   CraftingRecipe,
   ForgeRecipe,
@@ -200,6 +200,110 @@ export const getRequirementsAtDepth = (
   }
 
   return acc;
+};
+
+/**
+ * "Frontier" requirements for todo mode.
+ *
+ * Walks the crafting tree keyed by unique node PATH (root->node chain) and
+ * returns the most granular items still needed, given the set of checked-off
+ * node paths. Rules per node:
+ *  - path is checked        -> the whole subtree is done, contributes nothing.
+ *  - leaf / base material   -> it's a granular item still needed.
+ *  - has ingredients        -> recurse; if every child contributes nothing
+ *                              (all gathered) the node itself becomes the
+ *                              granular item to craft, otherwise return the
+ *                              union of the children's contributions.
+ *
+ * Output is aggregated by item name (Record<name, qty>), matching the shape of
+ * getBaseRequirements so list components need no structural change.
+ */
+export const getFrontierRequirements = (
+  internalname: string,
+  recipes: RecipesData,
+  multiplier: number,
+  checkedPaths: Set<string>,
+  path: string = internalname,
+  visited: Set<string> = new Set(),
+): Record<string, number> => {
+  // Entire subtree already gathered/crafted.
+  if (checkedPaths.has(path)) return {};
+
+  // Cycle guard (mirrors getBaseRequirements' branch-local visited): if this
+  // name already appears on the current branch, treat it as a leaf.
+  if (visited.has(internalname)) return { [internalname]: multiplier };
+
+  const entry = recipes[internalname];
+  const recipe = entry ? getRecipe(entry) : undefined;
+
+  // Leaf / base material -> the granular item still needed. Items missing from
+  // `recipes` (e.g. items.json-only) are treated as base here as well.
+  if (BASE_MATERIALS.has(internalname) || !entry || !recipe) {
+    return { [internalname]: multiplier };
+  }
+
+  const counts = aggregateIngredients(getIngredientsFromRecipe(recipe));
+  if (Object.keys(counts).length === 0) {
+    return { [internalname]: multiplier };
+  }
+
+  const newVisited = new Set(visited);
+  newVisited.add(internalname);
+
+  // Mirror recipe-tree's multiplier math: forge recipes craft 1 per run,
+  // crafting recipes craft `recipe.count` per run.
+  const isForge = (recipe as ForgeRecipe).type === "forge";
+  const recipeCount = !isForge
+    ? Number((recipe as Record<string, string | number>).count) || 1
+    : 1;
+  const actualMultiplier = Math.ceil(multiplier / recipeCount);
+
+  const childAcc: Record<string, number> = {};
+  for (const [name, count] of Object.entries(counts)) {
+    const childResult = getFrontierRequirements(
+      name,
+      recipes,
+      count * actualMultiplier,
+      checkedPaths,
+      `${path}${PATH_DELIM}${name}`,
+      newVisited,
+    );
+    for (const [material, qty] of Object.entries(childResult)) {
+      childAcc[material] = (childAcc[material] || 0) + qty;
+    }
+  }
+
+  // All ingredients gathered -> this node is now the granular item to craft.
+  if (Object.keys(childAcc).length === 0) {
+    return { [internalname]: multiplier };
+  }
+  return childAcc;
+};
+
+/**
+ * Combined frontier requirements for multiple items (multi-item mode). Each
+ * root's path is its own itemId, so paths from different roots never collide.
+ */
+export const getCombinedFrontierRequirements = (
+  itemList: Array<{ itemId: string; quantity: number }>,
+  recipes: RecipesData,
+  checkedPaths: Set<string>,
+): Record<string, number> => {
+  const combined: Record<string, number> = {};
+
+  for (const { itemId, quantity } of itemList) {
+    const requirements = getFrontierRequirements(
+      itemId,
+      recipes,
+      quantity,
+      checkedPaths,
+    );
+    for (const [material, count] of Object.entries(requirements)) {
+      combined[material] = (combined[material] || 0) + count;
+    }
+  }
+
+  return combined;
 };
 
 /**

--- a/apps/web/tests/recipe-utils.test.ts
+++ b/apps/web/tests/recipe-utils.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { PATH_DELIM } from "@/lib/constants";
 import {
   aggregateIngredients,
   getBaseRequirements,
+  getFrontierRequirements,
   getIngredientsFromRecipe,
   getRecipe,
 } from "@/lib/recipe-utils";
@@ -194,5 +196,91 @@ describe("getBaseRequirements", () => {
     expect(result).toEqual({
       IRON_INGOT: 320, // 160 * 2
     });
+  });
+});
+
+describe("getFrontierRequirements", () => {
+  // SUPER_ITEM -> 2x ENCHANTED_DIAMOND -> 160x DIAMOND
+  // GADGET -> WIDGET (-> 2x SCREW) + BOLT (-> 3x SCREW); SCREW appears twice.
+  let recipesData: RecipesData;
+
+  beforeEach(() => {
+    recipesData = {
+      SUPER_ITEM: {
+        internalname: "SUPER_ITEM",
+        recipe: { A1: "ENCHANTED_DIAMOND:2", count: "1" },
+      },
+      ENCHANTED_DIAMOND: {
+        internalname: "ENCHANTED_DIAMOND",
+        recipe: { A1: "DIAMOND:160", count: "1" },
+      },
+      DIAMOND: { internalname: "DIAMOND" },
+      GADGET: {
+        internalname: "GADGET",
+        recipe: { A1: "WIDGET:1", B1: "BOLT:1", count: "1" },
+      },
+      WIDGET: {
+        internalname: "WIDGET",
+        recipe: { A1: "SCREW:2", count: "1" },
+      },
+      BOLT: { internalname: "BOLT", recipe: { A1: "SCREW:3", count: "1" } },
+      SCREW: { internalname: "SCREW" },
+    };
+  });
+
+  it("returns the deepest base materials when nothing is checked", () => {
+    const result = getFrontierRequirements(
+      "SUPER_ITEM",
+      recipesData,
+      1,
+      new Set(),
+    );
+
+    expect(result).toEqual({ DIAMOND: 320 }); // 2 * 160
+  });
+
+  it("rolls up to the next un-crafted parent when a leaf is checked", () => {
+    const diamondPath = ["SUPER_ITEM", "ENCHANTED_DIAMOND", "DIAMOND"].join(
+      PATH_DELIM,
+    );
+
+    const result = getFrontierRequirements(
+      "SUPER_ITEM",
+      recipesData,
+      1,
+      new Set([diamondPath]),
+    );
+
+    // Diamonds gathered -> the next granular item is the enchanted diamond.
+    expect(result).toEqual({ ENCHANTED_DIAMOND: 2 });
+  });
+
+  it("treats duplicate appearances of an item independently", () => {
+    const screwUnderWidget = ["GADGET", "WIDGET", "SCREW"].join(PATH_DELIM);
+
+    const result = getFrontierRequirements(
+      "GADGET",
+      recipesData,
+      1,
+      new Set([screwUnderWidget]),
+    );
+
+    // The SCREW under WIDGET is done (so WIDGET rolls up), but the SCREW under
+    // BOLT is still independently needed.
+    expect(result).toEqual({ WIDGET: 1, SCREW: 3 });
+  });
+
+  it("excludes a whole subtree when a parent node is checked", () => {
+    const widgetPath = ["GADGET", "WIDGET"].join(PATH_DELIM);
+
+    const result = getFrontierRequirements(
+      "GADGET",
+      recipesData,
+      1,
+      new Set([widgetPath]),
+    );
+
+    // WIDGET (and its SCREW) gone; only BOLT's SCREW remains.
+    expect(result).toEqual({ SCREW: 3 });
   });
 });


### PR DESCRIPTION
Check-off state was keyed only by item internal name, so checking one appearance of an item also checked every other appearance, and checking a parent cascaded to those items everywhere in the tree.

Key `checkedItems` by each node's unique tree PATH (root->node internalname chain via PATH_DELIM) instead:
- Each appearance is now checked independently.
- A parent's cascade is scoped to its own subtree.
- Materials list / forge time use a new "frontier" computation that shows the most granular items still needed, rolling up to the next un-crafted parent as leaves are checked off.

Persisted localStorage shape is unchanged; stale name-based entries are inert.


Claude-Session: https://claude.ai/code/session_01PMz8bWPAhgdv8pBEDZnVCA